### PR TITLE
Use toString() representation of project.version

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/nexus/NexusPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/nexus/NexusPlugin.groovy
@@ -79,7 +79,8 @@ class NexusPlugin implements Plugin<Project> {
             if(extension.sign) {
                 project.signing {
                     required {
-                        project.gradle.taskGraph.hasTask(extension.getUploadTaskPath(project)) && !project.version.endsWith('SNAPSHOT')
+                        // Gradle allows project.version to be of type Object and always uses the toString() representation.
+                        project.gradle.taskGraph.hasTask(extension.getUploadTaskPath(project)) && !project.version.toString().endsWith('SNAPSHOT')
                     }
 
                     sign project.configurations[extension.configuration]


### PR DESCRIPTION
Gradle allows project.version to be of type Object and always calls
toString() on the version to get a String representation. Instead of
assuming that project.version is always a String, we need to do the same.

Fixes issue #38
