### PR TITLE
Throw exception when console is null and password is prompted

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/nexus/NexusPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/nexus/NexusPlugin.groovy
@@ -121,6 +121,10 @@ class NexusPlugin implements Plugin<Project> {
 
         if (!project.hasProperty(SIGNING_PASSWORD)) {
             String password = console.askForPassword('Please enter your passphrase to unlock the secret key')
+            if (password == null) {
+                throw new GradleException("Passphrase for GnuPG secret key needed, but none was provided. Try running" +
+                        " Gradle through the console with '--no-daemon'.");
+            }
             project.ext.set(SIGNING_PASSWORD, password)
         }
     }

--- a/src/main/groovy/com/bmuschko/gradle/nexus/NexusPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/nexus/NexusPlugin.groovy
@@ -116,14 +116,11 @@ class NexusPlugin implements Plugin<Project> {
             throw new GradleException("GnuPG secret key file $keyringFile not found. Please set $SIGNING_KEYRING=/path/to/file.gpg in <USER_HOME>/.gradle/gradle.properties.")
         }
 
+        ConsoleHandler console = new ConsoleHandler()
         console.printf "\nThis release $project.version will be signed with your GnuPG key $signingKeyId in $keyringFile.\n"
-        Console console = System.console()
 
-        if (console == null && !project.hasProperty(SIGNING_PASSWORD)) {
-            throw new GradleException("Passphrase for secret key needed, but no console was available. Try running" +
-                    " Gradle through the console with '--no-daemon'.");
-        } else if (!project.hasProperty(SIGNING_PASSWORD)) {
-            String password = new String(console.readPassword('Please enter your passphrase to unlock the secret key: '))
+        if (!project.hasProperty(SIGNING_PASSWORD)) {
+            String password = console.askForPassword('Please enter your passphrase to unlock the secret key')
             project.ext.set(SIGNING_PASSWORD, password)
         }
     }
@@ -186,11 +183,11 @@ class NexusPlugin implements Plugin<Project> {
 
                         String nexusUsername = project.hasProperty(NEXUS_USERNAME) ?
                                                project.property(NEXUS_USERNAME) :
-                                               consoleHandler.askForUsername()
+                                               consoleHandler.askForUsername('Please enter your Nexus username')
 
                         String nexusPassword = project.hasProperty(NEXUS_PASSWORD) ?
                                                project.property(NEXUS_PASSWORD) :
-                                               consoleHandler.askForPassword()
+                                               consoleHandler.askForPassword('Please enter your Nexus password')
 
                         if(extension.repositoryUrl) {
                             repository(url: extension.repositoryUrl) {
@@ -216,12 +213,18 @@ class NexusPlugin implements Plugin<Project> {
             console = System.console()
         }
 
-        String askForUsername() {
-            console ? console.readLine('\nPlease specify username: ') : null
+        void printf(String string, Object... args) {
+            if (console) {
+                console.printf(string, args)
+            }
         }
 
-        String askForPassword() {
-            console ? new String(console.readPassword('\nPlease specify password: ')) : null
+        String askForUsername(String promptMessage) {
+            console ? console.readLine("\n${promptMessage}: ") : null
+        }
+
+        String askForPassword(String promptMessage) {
+            console ? new String(console.readPassword("\n${promptMessage}: ")) : null
         }
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/nexus/NexusPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/nexus/NexusPlugin.groovy
@@ -116,10 +116,13 @@ class NexusPlugin implements Plugin<Project> {
             throw new GradleException("GnuPG secret key file $keyringFile not found. Please set $SIGNING_KEYRING=/path/to/file.gpg in <USER_HOME>/.gradle/gradle.properties.")
         }
 
-        Console console = System.console()
         console.printf "\nThis release $project.version will be signed with your GnuPG key $signingKeyId in $keyringFile.\n"
+        Console console = System.console()
 
-        if(!project.hasProperty(SIGNING_PASSWORD)) {
+        if (console == null && !project.hasProperty(SIGNING_PASSWORD)) {
+            throw new GradleException("Passphrase for secret key needed, but no console was available. Try running" +
+                    " Gradle through the console with '--no-daemon'.");
+        } else if (!project.hasProperty(SIGNING_PASSWORD)) {
             String password = new String(console.readPassword('Please enter your passphrase to unlock the secret key: '))
             project.ext.set(SIGNING_PASSWORD, password)
         }


### PR DESCRIPTION
When running `gradle uploadArchives` through the console while the Gradle daemon is running, a bizarre exception is thrown:

```
This release 1.7.1 will be signed with your GnuPG key in /home/alex/.gnupg/secring.gpg.

FAILURE: Build failed with an exception.

* What went wrong:
Cannot invoke method readPassword() on null object
```

This change modifies the code so that if a handler to a `Console` cannot be acquired, an appropriate exception is thrown.