### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ jdk:
   - oraclejdk8
 
 script:
-  - ./gradlew build -s
+  - ./gradlew build -s --scan

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,14 @@
 plugins {
+    id 'com.gradle.build-scan' version '1.16'
     id 'groovy'
     id 'java-gradle-plugin'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.8.4'
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 def compatibilityVersion = 1.6


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.