### PR TITLE
GPG CMD Signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ The plugin defines the following extension properties in the `extraArchive` clos
 The plugin defines the following extension properties in the `nexus` closure:
 
 * `sign`: Specifies whether to sign the artifacts using the [signing plugin](http://gradle.org/docs/current/userguide/signing_plugin.html) (defaults to true).
+* `signUseGpgCmd`: Whether to use GPG agent instead of Java-based implementation for signing (defaults to false).
+* `signReadPrivateKey`: Whether to read the private key passphrase from the console (defaults to true).
 * `configuration`: The custom configuration used to publish artifacts (defaults to `archives`).
 * `repositoryUrl`: The stable release repository URL (defaults to `https://oss.sonatype.org/service/local/staging/deploy/maven2/`).
 * `snapshotRepositoryUrl`: The snapshot repository URL (defaults to `https://oss.sonatype.org/content/repositories/snapshots/`).

--- a/src/main/groovy/com/bmuschko/gradle/nexus/NexusPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/nexus/NexusPlugin.groovy
@@ -78,6 +78,10 @@ class NexusPlugin implements Plugin<Project> {
         project.afterEvaluate {
             if(extension.sign) {
                 project.signing {
+                    if (extension.signUseGpgCmd) {
+                        useGpgCmd()
+                    }
+
                     required {
                         // Gradle allows project.version to be of type Object and always uses the toString() representation.
                         project.gradle.taskGraph.hasTask(extension.getUploadTaskPath(project)) && !project.version.toString().endsWith('SNAPSHOT')
@@ -86,7 +90,7 @@ class NexusPlugin implements Plugin<Project> {
                     sign project.configurations[extension.configuration]
 
                     project.gradle.taskGraph.whenReady {
-                        if(project.signing.required) {
+                        if(project.signing.required && extension.signReadPrivateKey) {
                             getPrivateKeyForSigning(project)
                         }
 

--- a/src/main/groovy/com/bmuschko/gradle/nexus/NexusPluginExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/nexus/NexusPluginExtension.groovy
@@ -28,6 +28,8 @@ import org.gradle.api.plugins.MavenPlugin
 class NexusPluginExtension {
     String configuration = Dependency.ARCHIVES_CONFIGURATION
     Boolean sign = true
+    Boolean signUseGpgCmd = false
+    Boolean signReadPrivateKey = true
     String repositoryUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
     String snapshotRepositoryUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
 


### PR DESCRIPTION
The current version of the plugin can only sign if the private key passphrase is stored somewhere on the machine.
Although there is a readConsole mechanism in place, this does not work at least not with current Gradle versions, because the Console object is always null.

The GPG implementation will already prompt for the passphrase though. To enable this feature, I added 2 configs:
1. whether to use gpg cmd instead of the default Java implementation
2. whether to read the passphrase from the console (if false, it won't try and instead rely on the gpg implementation to ask for it)